### PR TITLE
improve compatibillity with misconfigured web servers when resolving shortened URLs

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -51,7 +51,9 @@ async function resolveShorURL(url: string): Promise<string> {
             if (url.startsWith('https://')) {
                 https.get(url, {
                     headers: {
-                        'User-Agent': USER_AGENT
+                        'User-Agent': USER_AGENT,
+                        'Accept-Encoding': 'gzip, deflate, br',
+                        'Connection': 'keep-alive'
                     }
                 }, response => {
                     resolve(response.responseUrl);
@@ -62,7 +64,9 @@ async function resolveShorURL(url: string): Promise<string> {
             } else if (url.startsWith('http://')) {
                 http.get(url, {
                     headers: {
-                        'User-Agent': USER_AGENT
+                        'User-Agent': USER_AGENT,
+                        'Accept-Encoding': 'gzip, deflate, br',
+                        'Connection': 'keep-alive'
                     }
                 }, response => {
                     resolve(response.responseUrl);


### PR DESCRIPTION
When looking at the open issues I noticed #40  and thought I'd look into it. It seems the specific web server for the URL in the issue behaves quite badly, but adding some headers that I think should be safe for anything works around it. This does that.