### PR TITLE
Retry video upload

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -585,22 +585,22 @@ async function main() {
                                     const videoAgent = new AtpAgent({ service: "https://video.bsky.app" });
                                     
                                     while (!blob) {
-                                    const { data: status } = await videoAgent.app.bsky.video.getJobStatus(
-                                        { jobId: jobStatus.jobId },
-                                    );
-                                    console.log("  Status:",
-                                        status.jobStatus.state,
-                                        status.jobStatus.progress || "",
-                                    );
-                                    if (status.jobStatus.blob) {
-                                        blob = status.jobStatus.blob;
-                                    }
-                                    if (status.jobStatus.state === "JOB_STATE_FAILED") {
-                                        console.log("  Status: Video upload failed, retrying");
-                                        break;
-                                    }
-                                    // wait a second
-                                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                                        const { data: status } = await videoAgent.app.bsky.video.getJobStatus(
+                                            { jobId: jobStatus.jobId },
+                                        );
+                                        console.log("  Status:",
+                                            status.jobStatus.state,
+                                            status.jobStatus.progress || "",
+                                        );
+                                        if (status.jobStatus.blob) {
+                                            blob = status.jobStatus.blob;
+                                        }
+                                        if (status.jobStatus.state === "JOB_STATE_FAILED") {
+                                            console.log("  Status: Video upload failed, retrying");
+                                            break;
+                                        }
+                                        // wait a second
+                                        await new Promise((resolve) => setTimeout(resolve, 1000));
                                     }
                                 }
     


### PR DESCRIPTION
The Bsky video upload API can fail when processing a video blob and return JOB_STATE_FAILED, in which case the current code waits forever.
These failures are usually transient, so detecting the failure case and restarting the entire upload process should automatically heal the issue. I've tested this on my account which has a lot of video uploads and they've all been fine.