### PR TITLE
command line args support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,91 @@ They use the official archive export file format from X/Twitter, this utility re
 
 ## Getting started
 
-1. Install [Node.js](https://nodejs.org/) if you don't have it yet.
-2. In the project folder run: `npm i`
-3. Create an .env file in the project folder by setting the following variables:
+Before everything else, you need to request your Twitter archive. You can do this by following the instructions on the official Twitter support page: [Requesting your Twitter archive](https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive). This process may take a few days, and you will receive an email with a link to download the archive once it's ready.
+
+The program requires the Node.js runtime to be explicitly installed on your machine. You can check if you have it installed by running `node -v` in your terminal/console application. If you don't have it installed,
+you can download and install it from the official website: [Node.js](https://nodejs.org/)
+
+Once you have Node.js installed, and if you don't know what `git clone` means (don't go look it up, it's not important), you can download the source code as a zip file from this [GitHub repository](https://github.com/marcomaroni-github/twitter-to-bluesky/releases) and extract it to a folder on your computer. Pick the latest release.
+
+Navigate to the folder where you extracted the source code and open a terminal/console application in that folder. You can do this by typing `cmd` in the address bar of the folder in Windows or by right-clicking in the folder and selecting "Open in Terminal" in MacOS.
+
+In the project folder now run `npm install`. This will download and install all the modules required by the module to run.
+
+## Run the program
+
+You can run the program using command line arguments or environment variables. We recommend using command line arguments to start with, as they are easier to understand and manage.
+
+Mind that the program may have to run for a long time, potentially for several days, if you have a lot of tweets to import. It is recommended to run the program on a computer that you can leave running for a long time without interruptions. Once you hit your daily limit of posts, the program will display the time when the limit resets and wait until your limit is reset before continuing. You can put your computer to sleep while waiting. 
+
+If you have interrupted the program, you can restart it, and it will continue from where it left off. That information is stored in the "tweets_mapping.json" file in the project folder. Don't delete that file unless you want to start the import from scratch or import a different archive.
+
+### Using command line arguments
+
+To start the program, use: `npm run start -- -- [args]` where `[args]` are the arguments you want to pass to the program that are documented below. The double double-dashes may look a bit odd, but they are necessary to pass arguments to the program. (Not our choice, sorry!)
+
+## Required Arguments
+
+You need to gather your Twitter archive and create a Bluesky account before running the program.
+
+You must provide these arguments for the program to work:
+
+- `--archive-folder <path>` - The folder where your Twitter unzipped archive is stored 
+    Example: `--archive-folder "C:\Twitter\archive"`
+
+- `--bluesky-username <username>` - Your Bluesky account name
+    Example: `--bluesky-username myname.bsky.social`
+
+- `--bluesky-password <password>` - Your Bluesky account password
+    Example: `--bluesky-password mypassword123`
+
+- `--twitter-handles <handles>` - Your previous Twitter usernames (without @), separate multiple names with spaces. You only need to provide multiple handles if you ever changed your Twitter username for the same imported account. It is used to intercept replies to oneself (threads) and filter out some duplicate links included in the tweet text from the tweet archive.
+    Example: `--twitter-handles johndoe jane123`
+
+## Optional Arguments
+These arguments are optional and help customize the import:
+
+- `--simulate` - Test the import without actually posting. It is **highly recommended** to use this option first to see how many tweets will be imported and how long it will take.
+    Example: `--simulate`
+
+- `--disable-import-reply` - Skip importing tweet replies 
+    Example: `--disable-import-reply`
+
+- `--min-date YYYY-MM-DD` - Only import tweets posted after this date
+    Example: `--min-date 2020-01-01`
+
+- `--max-date YYYY-MM-DD` - Only import tweets posted before this date
+    Example: `--max-date 2023-12-31`
+
+- `--api-delay <milliseconds>` - Wait time between posts in milliseconds (default: 2500)
+    Example: `--api-delay 3000`
+
+## Examples when running on Windows
+
+Assuming you stored the Twitter archive in `C:\Temp\twitter-archive` and you want to import tweets from two Twitter handles:
+
+``` powershell
+npm run start -- -- --archive-folder C:\Temp\twitter-archive --bluesky-username test.bsky.social --bluesky-password pwd123 --twitter-handles sampleuser1 sampleuser2
+```
+
+## Examples when running on MacOS or Linux
+
+Assuming you stored the Twitter archive in your home folder and you want to import tweets from one Twitter handle:
+
+``` bash
+npm run start -- -- --archive-folder ~/twitter-archive --bluesky-username test.bsky.social --bluesky-password pwd123 --twitter-handles sampleuser1
+```
+
+### Using environment variables
+
+You can also set the required parameters using environment variables or a `.env` file.
+
+Create an .env file in the project folder where you set the following variables or set those in your environment:
+
 - `BLUESKY_USERNAME` = username into which you want to import the tweets (e.g. "test.bsky.social")
 - `BLUESKY_PASSWORD` = account password created via App Password (eg. "pwd123")
 - `ARCHIVE_FOLDER` = full path to the folder containing the X/Twitter archive (e.g. "C:/Temp/twitter-archive")
-- `PAST_HANDLES` - one or more x/twitter handles without @, comma separated (e.g. 'marcomaroni,user'). It is used to intercept replies to oneself (threads) and filter out some duplicate links included in the tweet text from the tweet archive.
-
-**I highly recommend trying to simulate the import first and import a small range of tweets, using the additional parameters documented below.**
-
-## Running the script 
-
-You can run the script locally: `npm start` or `npm run start_log` to write an import.log file.
-
-### Optional environment parameters
+- `PAST_HANDLES` - one or more x/twitter handles without @, comma separated (e.g. 'marcomaroni,user'). Corresponds to the `--twitter-handles` argument.
 
 Additionally you can set these environment variables to customize behavior:
 
@@ -41,6 +111,23 @@ Additionally you can set these environment variables to customize behavior:
 - `MIN_DATE` = indicates the minimum date of tweets to import, ISO format (e.g. '2011-01-01' or '2011-02-09T10:30:49.000Z').
 - `MAX_DATE` = indicates the maximum date of tweets to import, ISO format (e.g. '2012-01-01' or '2014-04-09T12:36:49.328Z').
 - `DISABLE_IMPORT_REPLY` = if set to 1 disables the import of replies to your tweets (threads).
+
+Example of a `.env` file:
+
+```
+BLUESKY_USERNAME=test.bsky.social
+BLUESKY_PASSWORD=pwd123
+ARCHIVE_FOLDER=C:/Temp/twitter-archive
+PAST_HANDLES=marcomaroni,user
+```
+
+Then you can run the script with `npm start` or `npm run start_log` to write an import.log file.
+
+**We highly recommend trying to simulate the import first and import a small range of tweets, using the additional parameters documented below.**
+
+## Running the script 
+
+You can run the script locally: `npm start` or `npm run start_log` to write an import.log file.
 
 ## License
 

--- a/app.ts
+++ b/app.ts
@@ -752,7 +752,7 @@ async function main() {
                 }
                
                 let externalEmbed = null;
-                if (tweet.entities?.urls) {
+                if (tweet.entities?.urls && !argv.simulate) {
                     for (const urlEntity of tweet.entities.urls) {
                         if (!urlEntity.expanded_url.startsWith('https://twitter.com') && !urlEntity.expanded_url.startsWith('https://x.com')) {
                             try {

--- a/app.ts
+++ b/app.ts
@@ -10,7 +10,7 @@ import sharp from 'sharp';
 import { AppBskyVideoDefs, AtpAgent, BlobRef, RichText } from '@atproto/api';
 
 import {
-    getEmbeddedUrlAndRecord, getMergeEmbed, getReplyRefs, PAST_HANDLES
+    getEmbeddedUrlAndRecord, getMergeEmbed, getReplyRefs
 } from './libs/bskyParams';
 import { checkPastHandles, convertToBskyPostUrl, getBskyPostUrl } from './libs/urlHandler';
 let fetch: any;
@@ -21,29 +21,21 @@ import { load } from 'cheerio'
 const oembetter = require('oembetter')();
 oembetter.endpoints(oembetter.suggestedEndpoints);
 
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+
+const TWEETS_MAPPING_FILE_NAME = 'tweets_mapping.json'; // store the imported tweets & bsky id mapping
+const MAX_FILE_SIZE = 1 * 1000 * 1000; // 1MiB
+const USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3';
+
 dotenv.config();
 
 const agent = new AtpAgent({
     service: 'https://bsky.social',
 })
 
-const SIMULATE = process.env.SIMULATE === "1";
-const API_DELAY = 2500; // https://docs.bsky.app/docs/advanced-guides/rate-limits
-const TWEETS_MAPPING_FILE_NAME = 'tweets_mapping.json'; // store the imported tweets & bsky id mapping
-const DISABLE_IMPORT_REPLY = process.env.DISABLE_IMPORT_REPLY === "1";
-const MAX_FILE_SIZE = 1 * 1000 * 1000; // 1MiB
-
-
-let MIN_DATE: Date | undefined = undefined;
-if (process.env.MIN_DATE != null && process.env.MIN_DATE.length > 0)
-    MIN_DATE = new Date(process.env.MIN_DATE as string);
-
-let MAX_DATE: Date | undefined = undefined;
-if (process.env.MAX_DATE != null && process.env.MAX_DATE.length > 0)
-    MAX_DATE = new Date(process.env.MAX_DATE as string);
-
 let alreadySavedCache = false;
-const USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3';
 
 class RateLimitedAgent {
     private agent: AtpAgent;
@@ -151,13 +143,15 @@ async function resolveShorURL(url: string): Promise<string> {
 }
 
 async function cleanTweetText(
-  tweetFullText: string, 
-  urlMappings: Array<{
-    url: string;
-    expanded_url: string
-  }>, 
-  embeddedUrl: string|null,
-  tweets
+    twitterHandles: string[],
+    blueskyUsername: string,
+    tweetFullText: string, 
+    urlMappings: Array<{
+        url: string;
+        expanded_url: string
+    }>, 
+    embeddedUrl: string|null,
+    tweets
 ): Promise<string> {
     let newText = tweetFullText;
     const urls: string[] = [];
@@ -180,12 +174,12 @@ async function cleanTweetText(
                 return urls[index];
             });
 
-            if (   checkPastHandles(newUrl) 
+            if (   checkPastHandles(twitterHandles, newUrl) 
                 && newUrl.indexOf("/photo/") == -1 
                 && newUrl.indexOf("/video/") == -1 
                 && embeddedUrl != newUrl) {
               // self quote exchange ( tweet-> bsky)
-              newUrls.push(convertToBskyPostUrl(newUrl, tweets))
+              newUrls.push(convertToBskyPostUrl(blueskyUsername, newUrl, tweets))
             }else{
               newUrls.push(newUrl)
             }
@@ -197,7 +191,7 @@ async function cleanTweetText(
             newText = URI.withinString(tweetFullText, (url, start, end, source) => {
                 // I exclude links to photos, because they have already been inserted into the Bluesky post independently
                 // also exclude embeddedUrl (ex. your twitter quote post)
-                if ( (checkPastHandles(newUrls[j]) && (newUrls[j].indexOf("/photo/") > 0 || newUrls[j].indexOf("/video/") > 0) )
+                if ( (checkPastHandles(twitterHandles, newUrls[j]) && (newUrls[j].indexOf("/photo/") > 0 || newUrls[j].indexOf("/video/") > 0) )
                   || embeddedUrl == newUrls[j]
                 ) {
                     j++;
@@ -221,7 +215,7 @@ function cleanTweetFileContent(fileContent) {
         .replace(/;$/, "");
 }
 
-function getTweets(){
+function getTweets(archiveFolder: string){
     // get cache (from last time imported)
     let caches = []
     if(FS.existsSync(TWEETS_MAPPING_FILE_NAME)){
@@ -229,12 +223,12 @@ function getTweets(){
     }
 
     // get original tweets
-    const fTweets = FS.readFileSync(process.env.ARCHIVE_FOLDER + "/data/tweets.js");
+    const fTweets = FS.readFileSync(path.join(archiveFolder, 'data', 'tweets.js'));
     let tweets = JSON.parse(cleanTweetFileContent(fTweets));
 
     let archiveExists = true;
     for (let i=1; archiveExists; i++) {
-        let archiveFile = `${process.env.ARCHIVE_FOLDER}/data/tweets-part${i}.js`;
+        let archiveFile = path.join(archiveFolder, 'data', `tweets-part${i}.js`);
         archiveExists = FS.existsSync(archiveFile)
         if( archiveExists ) {
             let fTweetsPart = FS.readFileSync(archiveFile);
@@ -434,11 +428,73 @@ async function recompressImageIfNeeded(imageData: string|ArrayBuffer): Promise<B
 }
 
 async function main() {
-    console.log(`Import started at ${new Date().toISOString()}`)
-    console.log(`SIMULATE is ${SIMULATE ? "ON" : "OFF"}`);
-    console.log(`IMPORT REPLY is ${!DISABLE_IMPORT_REPLY ? "ON" : "OFF"}`);
 
-    const tweets = getTweets();
+    const argv = yargs(hideBin(process.argv))
+        .option('simulate', {
+            type: 'boolean',
+            description: 'Simulate the import without making any changes (defaults to false)',
+            default: process.env.SIMULATE === '1',
+        })
+        .option('disable-import-reply', {
+            type: 'boolean',
+            description: 'Disable importing replies',
+            default: process.env.DISABLE_IMPORT_REPLY === '1',
+        })
+        .option('min-date', {
+            type: 'string',
+            description: 'Minimum date for tweets to import (YYYY-MM-DD)',
+            default: process.env.MIN_DATE,
+        })
+        .option('max-date', {
+            type: 'string',
+            description: 'Maximum date for tweets to import (YYYY-MM-DD)',
+            default: process.env.MAX_DATE,
+        })
+        .option('api-delay', {
+            type: 'number',
+            description: 'Delay between API calls in milliseconds',
+            default: process.env.API_DELAY ? parseInt(process.env.API_DELAY) : 2500,
+        })
+        .option('archive-folder', {
+            type: 'string',
+            description: 'Path to the archive folder',
+            default: process.env.ARCHIVE_FOLDER,
+            demandOption: true,
+        })
+        .option('bluesky-username', {
+            type: 'string',
+            description: 'Bluesky username',
+            default: process.env.BLUESKY_USERNAME,
+            demandOption: true,
+        })
+        .option('bluesky-password', {
+            type: 'string',
+            description: 'Bluesky password',
+            default: process.env.BLUESKY_PASSWORD,
+            demandOption: true,
+        })
+        .option('twitter-handles', {
+            type: 'array',
+            description: 'Twitter handles to import',
+            default: process.env.PAST_HANDLES?.split(','),
+            demandOption: true,
+        })
+        .help()
+        .argv;
+
+    let minDate = argv.minDate ? new Date(argv.minDate) : undefined;
+    let maxDate = argv.maxDate ? new Date(argv.maxDate) : undefined;
+
+    console.log(`Import started at ${new Date().toISOString()}`)
+    console.log(`Simulate is ${argv.simulate ? "ON" : "OFF"}`);
+    console.log(`Import Reply is ${!argv.disableImportReply ? "ON" : "OFF"}`);
+    console.log(`Min Date is ${minDate ? minDate.toISOString() : "OFF"}`);
+    console.log(`Max Date is ${maxDate ? maxDate.toISOString() : "OFF"}`);
+    console.log(`API Delay is ${argv.apiDelay}ms`);
+    console.log(`Archive Folder is ${argv.archiveFolder}`);
+    console.log(`Bluesky Username is ${argv.blueskyUsername}`);
+
+    const tweets = getTweets(argv.archiveFolder);
   
     let importedTweet = 0;
     if (tweets != null && tweets.length > 0) {
@@ -448,7 +504,7 @@ async function main() {
             return ad - bd;
         });
 
-        await rateLimitedAgent.login({ identifier: process.env.BLUESKY_USERNAME!, password: process.env.BLUESKY_PASSWORD! });
+        await rateLimitedAgent.login({ identifier: argv.blueskyUsername, password: argv.blueskyPassword });
        
         process.on('exit', () => saveCache(sortedTweets));
         process.on('SIGINT', () => process.exit());
@@ -461,9 +517,9 @@ async function main() {
                 const tweet_createdAt = tweetDate.toISOString();
 
                 //this cheks assume that the array is sorted by date (first the oldest)
-                if (MIN_DATE != undefined && tweetDate < MIN_DATE)
+                if (minDate != undefined && tweetDate < minDate)
                     continue;
-                if (MAX_DATE != undefined && tweetDate > MAX_DATE)
+                if (maxDate != undefined && tweetDate > maxDate)
                     break;
                 
                 if(bsky){
@@ -477,13 +533,13 @@ async function main() {
                 console.log(` Created at ${tweet_createdAt}`);
                 console.log(` Full text '${tweet.full_text}'`);
 
-                if (DISABLE_IMPORT_REPLY && tweet.in_reply_to_screen_name) {
+                if (argv.disableImportReply && tweet.in_reply_to_screen_name) {
                     console.log("Discarded (reply)");
                     continue;
                 }
 
                 if (tweet.in_reply_to_screen_name) {
-                    if (PAST_HANDLES.some(handle => tweet.in_reply_to_screen_name == handle)) {
+                    if (argv.twitterHandles.some(handle => tweet.in_reply_to_screen_name == handle)) {
                         // Remove "@screen_name" from the beginning of the tweet's full text
                         const replyPrefix = `@${tweet.in_reply_to_screen_name} `;
                         if (tweet.full_text.startsWith(replyPrefix)) {
@@ -537,7 +593,7 @@ async function main() {
                                 break;
                             }
 
-                            let mediaFilename = `${process.env.ARCHIVE_FOLDER}${path.sep}data${path.sep}tweets_media${path.sep}${tweet.id}-${media?.media_url.substring(i + 1)}`;
+                            let mediaFilename = `${argv.archiveFolder}${path.sep}data${path.sep}tweets_media${path.sep}${tweet.id}-${media?.media_url.substring(i + 1)}`;
 
                             let localMediaFileNotFound = true;
                             if (FS.existsSync(mediaFilename)) {
@@ -545,7 +601,7 @@ async function main() {
                             }
 
                             if (localMediaFileNotFound) {
-                                const wildcardPath = `${process.env.ARCHIVE_FOLDER}${path.sep}data${path.sep}tweets_media${path.sep}${tweet.id}-*`;
+                                const wildcardPath = `${argv.archiveFolder}${path.sep}data${path.sep}tweets_media${path.sep}${tweet.id}-*`;
                                 const files = FS.readdirSync(path.dirname(wildcardPath)).filter(file => file.startsWith(`${tweet.id}-`));
 
                                 if (files.length > 0) {
@@ -567,7 +623,7 @@ async function main() {
                                 mimeType = 'image/jpeg';
                             }
 
-                            if (!SIMULATE) {
+                            if (!argv.simulate) {
                                 const blobRecord = await rateLimitedAgent.uploadBlob(imageBuffer, {
                                     encoding: mimeType
                                 });
@@ -590,7 +646,7 @@ async function main() {
                                 tweet.full_text = tweet.full_text.replace(media?.url, '').replace(/\s\s+/g, ' ').trim();
                             }
 
-                            const baseVideoPath = `${process.env.ARCHIVE_FOLDER}/data/tweets_media/${tweet.id}-`;
+                            const baseVideoPath = `${argv.archiveFolder}/data/tweets_media/${tweet.id}-`;
                             let videoFileName = '';
                             let videoFilePath = '';
                             let localVideoFileNotFound = true;
@@ -611,7 +667,7 @@ async function main() {
                                 continue
                             }
     
-                            if (!SIMULATE) {
+                            if (!argv.simulate) {
                                 const { data: serviceAuth } = await rateLimitedAgent.getServiceAuth(
                                     {
                                       aud: `did:web:${rateLimitedAgent.dispatchUrl.host}`,
@@ -674,16 +730,16 @@ async function main() {
                 }
 
                 // handle bsky embed record
-                const { embeddedUrl = null, embeddedRecord = null } = getEmbeddedUrlAndRecord(tweet.entities?.urls, sortedTweets);
+                const { embeddedUrl = null, embeddedRecord = null } = getEmbeddedUrlAndRecord(argv.twitterHandles, tweet.entities?.urls, sortedTweets);
 
                 let replyTo: {}|null = null; 
-                if ( !DISABLE_IMPORT_REPLY && !SIMULATE && tweet.in_reply_to_screen_name) {
-                    replyTo = getReplyRefs(tweet,sortedTweets);
+                if ( !argv.disableImportReply && !argv.simulate && tweet.in_reply_to_screen_name) {
+                    replyTo = getReplyRefs(argv.twitterHandles, tweet, sortedTweets);
                 }
 
                 let postText = tweet.full_text as string;
-                if (!SIMULATE) {
-                    postText = await cleanTweetText(tweet.full_text, tweet.entities?.urls, embeddedUrl, sortedTweets);
+                if (!argv.simulate) {
+                    postText = await cleanTweetText(argv.twitterHandles, argv.blueskyUsername, tweet.full_text, tweet.entities?.urls, embeddedUrl, sortedTweets);
 
                     if (postText.length > 300)
                         postText = tweet.full_text;
@@ -747,16 +803,16 @@ async function main() {
 
                 console.log(postRecord);
 
-                if (!SIMULATE) {
+                if (!argv.simulate) {
                     //I wait 3 seconds so as not to exceed the api rate limits
-                    await new Promise(resolve => setTimeout(resolve, API_DELAY));
+                    await new Promise(resolve => setTimeout(resolve, argv.apiDelay));
 
                     try 
                     {
                         const recordData = await rateLimitedAgent.post(postRecord);
                         const i = recordData.uri.lastIndexOf("/");
                         if (i > 0) {
-                            const postUri = getBskyPostUrl(recordData.uri);
+                            const postUri = getBskyPostUrl(argv.blueskyUsername, recordData.uri);
                             console.log("Bluesky post create, URL: " + postUri);
 
                             importedTweet++;
@@ -786,9 +842,9 @@ async function main() {
         }
     }
 
-    if (SIMULATE) {
+    if (argv.simulate) {
         // In addition to the delay in AT Proto API calls, we will also consider a 5% delta for URL resolution calls
-        const minutes = Math.round((importedTweet * API_DELAY / 1000) / 60) + (1 / 0.1);
+        const minutes = Math.round((importedTweet * argv.apiDelay / 1000) / 60) + (1 / 0.1);
         const hours = Math.floor(minutes / 60);
         const min = minutes % 60;
         console.log(`Estimated time for real import: ${hours} hours and ${min} minutes`);

--- a/libs/bskyAPI.ts
+++ b/libs/bskyAPI.ts
@@ -1,23 +1,8 @@
-import * as dotenv from 'dotenv';
-import * as process from 'process';
 import FS from 'fs';
-
-dotenv.config();
 
 export const TWEETS_MAPPING_FILE_NAME = 'tweets_mapping.json'; // store the imported tweets & bsky id mapping
 
-
-let MIN_DATE: Date | undefined = undefined;
-if (process.env.MIN_DATE != null && process.env.MIN_DATE.length > 0)
-    MIN_DATE = new Date(process.env.MIN_DATE as string);
-
-let MAX_DATE: Date | undefined = undefined;
-if (process.env.MAX_DATE != null && process.env.MAX_DATE.length > 0)
-    MAX_DATE = new Date(process.env.MAX_DATE as string);
-
-
-
-export async function deleteBskyPosts(agent, tweets){
+export async function deleteBskyPosts(agent, tweets, minDate: Date, maxDate: Date){
 // Delete bsky posts with a record in TWEETS_MAPPING_FILE_NAME.
 // If something goes wrong, call this method to clear the previously imported posts.
 // You may also use MIN_DATE and MAX_DATE to limit the range.
@@ -30,9 +15,9 @@ export async function deleteBskyPosts(agent, tweets){
               
                 const tweetDate = new Date(tweet.created_at);
       
-                if (MIN_DATE != undefined && tweetDate < MIN_DATE)
+                if (minDate != undefined && tweetDate < minDate)
                     continue;
-                if (MAX_DATE != undefined && tweetDate > MAX_DATE)
+                if (maxDate != undefined && tweetDate > maxDate)
                     continue;
                 
                 await agent.deletePost(bsky.uri);

--- a/libs/bskyParams.ts
+++ b/libs/bskyParams.ts
@@ -1,13 +1,8 @@
-import * as dotenv from 'dotenv';
-import * as process from 'process';
-
 import { checkPastHandles } from './urlHandler';
 
-dotenv.config();
-
-export const PAST_HANDLES = process.env.PAST_HANDLES!.split(",");
-
-export function getReplyRefs({in_reply_to_screen_name, in_reply_to_status_id}, tweets):{
+export function getReplyRefs(
+    twitterHandles: string[],
+    {in_reply_to_screen_name, in_reply_to_status_id}, tweets):{
     "root": {
         "uri": string;
         "cid": string;
@@ -17,7 +12,7 @@ export function getReplyRefs({in_reply_to_screen_name, in_reply_to_status_id}, t
         "cid":string;
     },
 }|null{
-    const importReplyScreenNames = PAST_HANDLES || [];
+    const importReplyScreenNames = twitterHandles || [];
     if(importReplyScreenNames.every(handle => in_reply_to_screen_name != handle)){
         console.log(`Skip Reply (wrong reply screen name :${in_reply_to_screen_name})`, importReplyScreenNames);
         return null;
@@ -48,6 +43,7 @@ export function getReplyRefs({in_reply_to_screen_name, in_reply_to_status_id}, t
 
 
 export function getEmbeddedUrlAndRecord(
+    twitterHandles: string[],
     urls: Array<{expanded_url: string}>, 
     tweets: Array<{
         tweet: Record<string, string>,
@@ -68,7 +64,7 @@ export function getEmbeddedUrlAndRecord(
 
     // get the last one url to embed
     const reversedUrls = urls.reverse(); 
-    embeddedTweetUrl = reversedUrls.find(({expanded_url})=> checkPastHandles(expanded_url))?.expanded_url ?? null;
+    embeddedTweetUrl = reversedUrls.find(({expanded_url})=> checkPastHandles(twitterHandles, expanded_url))?.expanded_url ?? null;
     
     if(!embeddedTweetUrl){
         return nullResult;

--- a/libs/urlHandler.ts
+++ b/libs/urlHandler.ts
@@ -1,18 +1,13 @@
-import * as dotenv from 'dotenv';
-import * as process from 'process';
 
-dotenv.config();
-
-export const PAST_HANDLES = process.env.PAST_HANDLES!.split(",");
-
-export function checkPastHandles(url: string): boolean{
-    return (PAST_HANDLES || []).some(handle => 
+export function checkPastHandles(twitterHandles: string[], url: string): boolean{
+    return (twitterHandles || []).some(handle => 
         url.startsWith(`https://x.com/${handle}/`) || 
         url.startsWith(`https://twitter.com/${handle}/`)
     )
 }
 
 export function convertToBskyPostUrl(
+    blueskyUsername: string,
     tweetUrl:string , 
     tweets: Array<{
             tweet: Record<string, string>,
@@ -29,16 +24,16 @@ export function convertToBskyPostUrl(
     if(!tweet?.bsky){
         return tweetUrl;
     }
-    return getBskyPostUrl(tweet.bsky.uri);
+    return getBskyPostUrl(blueskyUsername, tweet.bsky.uri);
 }
 
-export function getBskyPostUrl(bskyUri: string): string {
+export function getBskyPostUrl(blueskyUsername : string, bskyUri: string): string {
     const i = bskyUri.lastIndexOf("/");
     if(i == -1){
         return bskyUri;
     }
     const rkey = bskyUri.substring(i + 1);
-    return `https://bsky.app/profile/${process.env.BLUESKY_USERNAME!}/post/${rkey}`;
+    return `https://bsky.app/profile/${blueskyUsername!}/post/${rkey}`;
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "process": "^0.11.10",
         "sharp": "^0.33.5",
         "typescript": "^5.6.3",
-        "urijs": "^1.19.11"
+        "urijs": "^1.19.11",
+        "yargs": "17.7.2"
       },
       "devDependencies": {
         "@types/follow-redirects": "^1.14.4",
@@ -465,6 +466,30 @@
       "integrity": "sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==",
       "dev": true
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/async": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -518,6 +543,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color": {
@@ -661,6 +700,12 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
@@ -682,6 +727,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -757,6 +811,15 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -804,6 +867,15 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/iso-datestring-validator": {
       "version": "2.2.2",
@@ -934,6 +1006,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -994,6 +1075,32 @@
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strnum": {
@@ -1104,6 +1211,59 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "sharp": "^0.33.5",
     "cheerio": "^1.0.0",
     "node-fetch": "^3.3.2",
-    "oembetter": "1.1.4"
+    "oembetter": "1.1.4",
+    "yargs": "17.7.2"
   },
   "devDependencies": {
     "@types/follow-redirects": "^1.14.4",


### PR DESCRIPTION
This PR consolidates the existing evaluation of environment variables into main() and introduces parameters into the utility functions where the environment is currently referenced directly.

The main() function uses yargs to parse parameters off the command line, with default values taken from the existing environment parameters. The app should thus run as before when using the .env file or explicitly set environment variables.

when using "npm start", the parameters must be passed by two (!) sets of double-dashes, e.g.

`npm start -- -- npm run start -- -- --twitter-handles clemensv --bluesky-username clemens-archive.vasters.com --archive-folder m:\twitter --bluesky-password ********** --min-date 2015-08-21`

That's a "feature" of npm, not of the script. 

This is in prep for bundling the app into a self-contained executable.