### PR TITLE
Fix tweet sorting

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -545,9 +545,7 @@ async function main() {
     let importedTweet = 0;
     if (tweets != null && tweets.length > 0) {
         const sortedTweets = tweets.sort((a, b) => {
-            let ad = new Date(a.tweet.created_at).getTime();
-            let bd = new Date(b.tweet.created_at).getTime();
-            return ad - bd;
+            return parseInt(a.tweet.id) - parseInt(b.tweet.id);
         });
 
         await rateLimitedAgent.login({ identifier: argv.blueskyUsername, password: argv.blueskyPassword });

--- a/app.ts
+++ b/app.ts
@@ -545,7 +545,16 @@ async function main() {
     let importedTweet = 0;
     if (tweets != null && tweets.length > 0) {
         const sortedTweets = tweets.sort((a, b) => {
-            return parseInt(a.tweet.id) - parseInt(b.tweet.id);
+            const idA = BigInt(a.tweet.id);
+            const idB = BigInt(b.tweet.id);
+                
+            if (idA < idB)
+                return -1;
+            
+            if (idA > idB)
+                return 1;
+
+            return 0;
         });
 
         await rateLimitedAgent.login({ identifier: argv.blueskyUsername, password: argv.blueskyPassword });


### PR DESCRIPTION
This PR sorts tweets by ID instead of date.

It is necessary to sort by ID to ensure that references are never broken.

For example, when importing threads, especially those created all at once from the web interface, the date of two consecutive tweets may be exactly the same.