### PR TITLE
add support to strip image metadata before uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Additionally you can set these environment variables to customize behavior:
 - `API_DELAY` = Delay between Bluesky API calls in milliseconds
 - `IGNORE_VIDEO_ERRORS` = if set to "1" continue processing tweets when a video submission fails
 - `VIDEO_UPLOAD_RETRIES` = set to the number of times to attempt to upload a video if JOB_STATE_FAILED encountered
+- `STRIP_IMAGE_METADATA` = if set to "1" will strip EXIF metadata from images before uploading them to Bluesky
 
 **Example of a `.env` file:**
 
@@ -118,6 +119,9 @@ These arguments are optional and help customize the import:
 
 - `--video-upload-retries` - Number of times to retry uploading videos if JOB_STATE_FAILED encountered.
     Example: `--video-upload-retries 5`
+
+- `--strip-image-metadata` - Strip EXIF metadata from images before they're uploaded to Bluesky
+    Example: `--strip-image-metadata`
 
 **Examples when running on Windows**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@atproto/api": "^0.13.12",
         "cheerio": "^1.0.0",
         "dotenv": "^16.4.5",
+        "exiftool-vendored": "^29.0.0",
         "follow-redirects": "^1.15.6",
         "he": "^1.2.0",
         "node-fetch": "^3.3.2",
@@ -435,6 +436,12 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@photostructure/tz-lookup": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-11.0.0.tgz",
+      "integrity": "sha512-QMV5/dWtY/MdVPXZs/EApqzyhnqDq1keYEqpS+Xj2uidyaqw2Nk/fWcsszdruIXjdqp1VoWNzsgrO6bUHU1mFw==",
+      "license": "CC0-1.0"
+    },
     "node_modules/@types/follow-redirects": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.14.4.tgz",
@@ -449,6 +456,12 @@
       "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
       "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -499,6 +512,15 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
       "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw=="
+    },
+    "node_modules/batch-cluster": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/batch-cluster/-/batch-cluster-13.0.0.tgz",
+      "integrity": "sha512-EreW0Vi8TwovhYUHBXXRA5tthuU2ynGsZFlboyMJHCCUXYa2AjgwnE3ubBOJs2xJLcuXFJbi6c/8pH5+FVj8Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -738,6 +760,43 @@
         "node": ">=6"
       }
     },
+    "node_modules/exiftool-vendored": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-29.0.0.tgz",
+      "integrity": "sha512-BW2Fr7okYP1tN7KIIREy8gOx9WggpPsbKc3BTAS4dLgSup50LjdQttxF9kyDP+27ZayllK+d0rfMYPAixPBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@photostructure/tz-lookup": "^11.0.0",
+        "@types/luxon": "^3.4.2",
+        "batch-cluster": "^13.0.0",
+        "he": "^1.2.0",
+        "luxon": "^3.5.0"
+      },
+      "optionalDependencies": {
+        "exiftool-vendored.exe": "13.0.0",
+        "exiftool-vendored.pl": "13.0.1"
+      }
+    },
+    "node_modules/exiftool-vendored.exe": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-13.0.0.tgz",
+      "integrity": "sha512-4zAMuFGgxZkOoyQIzZMHv1HlvgyJK3AkNqjAgm8A8V0UmOZO7yv3pH49cDV1OduzFJqgs6yQ6eG4OGydhKtxlg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/exiftool-vendored.pl": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-13.0.1.tgz",
+      "integrity": "sha512-+BRRzjselpWudKR0ltAW5SUt9T82D+gzQN8DdOQUgnSVWWp7oLCeTGBRptbQz+436Ihn/mPzmo/xnf0cv/Qw1A==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!win32"
+      ]
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
@@ -881,6 +940,15 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
       "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA=="
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/multiformats": {
       "version": "9.9.0",

--- a/package.json
+++ b/package.json
@@ -15,16 +15,17 @@
   "license": "ISC",
   "dependencies": {
     "@atproto/api": "^0.13.12",
+    "cheerio": "^1.0.0",
     "dotenv": "^16.4.5",
+    "exiftool-vendored": "^29.0.0",
     "follow-redirects": "^1.15.6",
     "he": "^1.2.0",
-    "process": "^0.11.10",
-    "typescript": "^5.6.3",
-    "urijs": "^1.19.11",
-    "sharp": "^0.33.5",
-    "cheerio": "^1.0.0",
     "node-fetch": "^3.3.2",
     "oembetter": "1.1.4",
+    "process": "^0.11.10",
+    "sharp": "^0.33.5",
+    "typescript": "^5.6.3",
+    "urijs": "^1.19.11",
     "yargs": "17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds an extra command-line argument to remove image metadata before uploading them to Bluesky, based on the best practices documented here: [https://docs.bsky.app/docs/advanced-guides/posts](https://docs.bsky.app/docs/advanced-guides/posts). I've set it set to false by default, I think given the documentation it could be set to true.

I also added "mimeType = 'image/jpeg';" on line 328 in app.ts. Unless I missed something, I believe it needs to be there as recompress always delivers a jpeg image.