### PR TITLE
update readme: verified email required

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ They use the official archive export file format from X/Twitter, this utility re
 
 - Nodejs >= 20.12x
 - The archive of your tweets from the X/Twitter, unzipped in your local disk.
+- A Bluesky account, with verified e-mail (otherwise videos will not upload).
 
 ## Breaking changes from version < 0.10
 

--- a/app.ts
+++ b/app.ts
@@ -767,7 +767,7 @@ async function main() {
                                 
                                 const jobStatus = (await uploadResponse.json()) as AppBskyVideoDefs.JobStatus;
                                 if (jobStatus.error) {
-                                    console.warn(` Video job status: '${jobStatus.error}'. Video will be posted as a link`);
+                                    console.warn(` Video job status: '${jobStatus.error}'. Video will not be posted.`);
                                 }
                                 console.log(" JobId:", jobStatus.jobId);
                                 if (jobStatus.jobId || !argv.ignoreVideoErrors) {


### PR DESCRIPTION
Attempting to upload videos when the Bluesky account is not verified results in a "unconfirmed_email" error and the videos not being uploaded.

related: https://github.com/bluesky-social/atproto/issues/3097